### PR TITLE
Expose new admin decorators in django.contrib.admin

### DIFF
--- a/typings/django/contrib/admin/__init__.pyi
+++ b/typings/django/contrib/admin/__init__.pyi
@@ -1,4 +1,6 @@
 from . import checks as checks
+from .decorators import action as action
+from .decorators import display as display
 from .decorators import register as register
 from .filters import AllValuesFieldListFilter as AllValuesFieldListFilter
 from .filters import BooleanFieldListFilter as BooleanFieldListFilter


### PR DESCRIPTION
I forgot this important step in #37.