### PR TITLE
Fields typing improvements

### DIFF
--- a/django-stubs/contrib/postgres/fields/array.pyi
+++ b/django-stubs/contrib/postgres/fields/array.pyi
@@ -1,22 +1,18 @@
 from typing import (
     Any,
+    Callable,
     Generic,
     Iterable,
     List,
     Optional,
-    Sequence,
+    Tuple,
     TypeVar,
     Union,
     overload,
 )
 
 from django.db.models.expressions import Combinable
-from django.db.models.fields import (
-    Field,
-    _ErrorMessagesToOverride,
-    _FieldChoices,
-    _ValidatorCallable,
-)
+from django.db.models.fields import Field, _ErrorMessagesToOverride, _ValidatorCallable
 from typing_extensions import Literal
 
 from .mixins import CheckFieldDefaultMixin
@@ -26,7 +22,7 @@ _T = TypeVar("_T", bound=Optional[List[Any]])
 class ArrayField(
     Generic[_T],
     CheckFieldDefaultMixin,
-    Field[Union[Sequence[Any], Combinable], List[Any]],
+    Field[Union[_T, Combinable], _T],
 ):
 
     empty_strings_allowed: bool = ...
@@ -36,11 +32,11 @@ class ArrayField(
     default_validators: Any = ...
     from_db_value: Any = ...
     @overload
-    def __new__(  # type: ignore [misc]
-        cls,
+    def __init__(
+        self: ArrayField[List[Any]],
         base_field: Field[Any, Any],
         size: Optional[int] = ...,
-        verbose_name: Optional[Union[str, bytes]] = ...,
+        verbose_name: Optional[str] = ...,
         name: Optional[str] = ...,
         primary_key: bool = ...,
         max_length: Optional[int] = ...,
@@ -48,26 +44,28 @@ class ArrayField(
         blank: bool = ...,
         null: Literal[False] = ...,
         db_index: bool = ...,
-        default: Any = ...,
+        default: Union[_T, Callable[[], _T]] = ...,
         editable: bool = ...,
         auto_created: bool = ...,
         serialize: bool = ...,
         unique_for_date: Optional[str] = ...,
         unique_for_month: Optional[str] = ...,
         unique_for_year: Optional[str] = ...,
-        choices: Optional[_FieldChoices] = ...,
+        choices: Iterable[
+            Union[Tuple[_T, str], Tuple[str, Iterable[Tuple[_T, str]]]]
+        ] = ...,
         help_text: str = ...,
         db_column: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: Optional[_ErrorMessagesToOverride] = ...,
-    ) -> ArrayField[List[Any]]: ...
+    ) -> None: ...
     @overload
-    def __new__(
-        cls,
+    def __init__(
+        self: ArrayField[Optional[List[Any]]],
         base_field: Field[Any, Any],
         size: Optional[int] = ...,
-        verbose_name: Optional[Union[str, bytes]] = ...,
+        verbose_name: Optional[str] = ...,
         name: Optional[str] = ...,
         primary_key: bool = ...,
         max_length: Optional[int] = ...,
@@ -75,22 +73,54 @@ class ArrayField(
         blank: bool = ...,
         null: Literal[True] = ...,
         db_index: bool = ...,
-        default: Any = ...,
+        default: Optional[Union[_T, Callable[[], _T]]] = ...,
         editable: bool = ...,
         auto_created: bool = ...,
         serialize: bool = ...,
         unique_for_date: Optional[str] = ...,
         unique_for_month: Optional[str] = ...,
         unique_for_year: Optional[str] = ...,
-        choices: Optional[_FieldChoices] = ...,
+        choices: Iterable[
+            Union[Tuple[_T, str], Tuple[str, Iterable[Tuple[_T, str]]]]
+        ] = ...,
         help_text: str = ...,
         db_column: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: Optional[_ErrorMessagesToOverride] = ...,
+    ) -> None: ...
+    @overload
+    def __new__(
+        cls,
+        *args: Any,
+        null: Literal[False] = ...,
+        choices: None = ...,
+        **kwargs: Any,
+    ) -> ArrayField[List[Any]]: ...
+    @overload
+    def __new__(
+        cls,
+        *args: Any,
+        null: Literal[True],
+        choices: None = ...,
+        **kwargs: Any,
     ) -> ArrayField[Optional[List[Any]]]: ...
-    def __get__(self: ArrayField[_T], instance: Any, owner: Any) -> _T: ...  # type: ignore [override]
-    def __set__(self: ArrayField[_T], instance: Any, value: _T) -> None: ...  # type: ignore [override]
+    @overload
+    def __new__(
+        cls,
+        *args: Any,
+        null: Literal[False] = ...,
+        choices: Iterable[Union[Tuple[_T, str], Tuple[str, Iterable[Tuple[_T, str]]]]],
+        **kwargs: Any,
+    ) -> ArrayField[_T]: ...
+    @overload
+    def __new__(
+        cls,
+        *args: Any,
+        null: Literal[True],
+        choices: Iterable[Union[Tuple[_T, str], Tuple[str, Iterable[Tuple[_T, str]]]]],
+        **kwargs: Any,
+    ) -> ArrayField[Optional[_T]]: ...
     @property
     def description(self) -> str: ...  # type: ignore [override]
     def get_transform(self, name: Any) -> Any: ...

--- a/s/lint
+++ b/s/lint
@@ -2,20 +2,21 @@
 
 set -ex
 
-
 # format code
 if [[ $CI ]]; then
-    ./.venv/bin/black --check tests typings
-    ./.venv/bin/isort --check-only tests typings
+  ./.venv/bin/black --check tests typings
+  ./.venv/bin/isort --check-only tests typings
 else
-    ./.venv/bin/black tests typings
-    ./.venv/bin/isort tests typings
+  ./.venv/bin/black tests typings
+  ./.venv/bin/isort tests typings
 fi
 
 # type check code
 ./.venv/bin/mypy tests typings
 
+# pyright tests
 ./node_modules/.bin/pyright tests typings
+./.venv/bin/pytest tests typings -p no:warnings -v
 
 # lint
 ./.venv/bin/flake8 tests typings

--- a/tests/pyright/base.py
+++ b/tests/pyright/base.py
@@ -1,0 +1,46 @@
+# Slighly based on https://github.com/strawberry-graphql/strawberry/blob/main/tests/pyright/utils.py
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import List, cast
+
+from typing_extensions import Literal
+
+_cwd = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_bin = os.path.join(_cwd, "node_modules", ".bin", "pyright")
+
+
+@dataclass
+class Result:
+    type: Literal["error", "info"]
+    message: str
+    line: int
+    column: int
+
+    @classmethod
+    def from_output_line(cls, output_line: str) -> "Result":
+        # an output line looks like: filename.py:11:6 - type: Message
+        file_info, result = output_line.split("-", maxsplit=1)
+
+        line, column = [int(value) for value in file_info.split(":")[1:]]
+        type_, message = [value.strip() for value in result.split(":", maxsplit=1)]
+        type_ = cast(Literal["error", "info"], type_)
+
+        return cls(type=type_, message=message, line=line, column=column)
+
+
+def run_pyright(code: str) -> List[Result]:
+    with tempfile.NamedTemporaryFile("w", suffix=".py") as f:
+        f.write(code)
+        f.flush()
+        result = subprocess.run([_bin, f.name], cwd=_cwd, stdout=subprocess.PIPE)
+
+    output = result.stdout.decode("utf-8")
+    results: List[Result] = []
+    for line in output.splitlines():
+        if line.strip().startswith(f"{f.name}:"):
+            results.append(Result.from_output_line(line))
+
+    return results

--- a/tests/pyright/test_fields.py
+++ b/tests/pyright/test_fields.py
@@ -1,0 +1,185 @@
+from .base import Result, run_pyright
+
+
+def test_integer_with_choices() -> None:
+    results = run_pyright(
+        """\
+from django.db import models
+
+class Foo(models.Model):
+    integer_with_choices = models.IntegerField(
+        choices=[
+            (1, "First Option"),
+            (2, "Second Option"),
+        ],
+    )
+
+f = Foo()
+reveal_type(f.integer_with_choices)
+f.integer_with_choices == 2
+f.integer_with_choices == 3
+f.integer_with_choices = None
+f.integer_with_choices = 3
+f.integer_with_choices = 2
+"""
+    )
+    assert results == [
+        Result(
+            type="info",
+            message='Type of "f.integer_with_choices" is "Literal[1, 2]"',
+            line=12,
+            column=13,
+        ),
+        Result(
+            type="error",
+            message=(
+                "Condition will always evaluate to False since the types "
+                '"Literal[1, 2]" and "Literal[3]" have no overlap (reportUnnecessaryComparison)'
+            ),
+            line=14,
+            column=1,
+        ),
+        Result(
+            type="error",
+            message='Cannot assign member "integer_with_choices" for type "Foo" (reportGeneralTypeIssues)',
+            line=15,
+            column=3,
+        ),
+        Result(
+            type="error",
+            message='Cannot assign member "integer_with_choices" for type "Foo" (reportGeneralTypeIssues)',
+            line=16,
+            column=3,
+        ),
+    ]
+
+
+def test_integer_with_choices_nullable() -> None:
+    results = run_pyright(
+        """\
+from django.db import models
+
+class Foo(models.Model):
+    integer_with_choices_nullable = models.IntegerField(
+        choices=[
+            (1, "First Option"),
+            (2, "Second Option"),
+        ],
+        null=True,
+    )
+
+f = Foo()
+reveal_type(f.integer_with_choices_nullable)
+f.integer_with_choices_nullable == 2
+f.integer_with_choices_nullable == 3
+f.integer_with_choices_nullable = None
+f.integer_with_choices_nullable = 3
+f.integer_with_choices_nullable = 2
+"""
+    )
+    assert results == [
+        Result(
+            type="info",
+            message='Type of "f.integer_with_choices_nullable" is "Literal[1, 2] | None"',
+            line=13,
+            column=13,
+        ),
+        Result(
+            type="error",
+            message=(
+                'Cannot assign member "integer_with_choices_nullable" for type '
+                '"Foo" (reportGeneralTypeIssues)'
+            ),
+            line=17,
+            column=3,
+        ),
+    ]
+
+
+def test_char_with_choices() -> None:
+    results = run_pyright(
+        """\
+from django.db import models
+
+class Foo(models.Model):
+    char_with_choices = models.CharField(
+        choices=[
+            ("a", "A"),
+            ("b", "B"),
+        ],
+    )
+
+f = Foo()
+reveal_type(f.char_with_choices)
+f.char_with_choices == "c"
+f.char_with_choices == "a"
+f.char_with_choices = None
+f.char_with_choices = "c"
+f.char_with_choices = "b"
+"""
+    )
+    assert results == [
+        Result(
+            type="info",
+            message="Type of \"f.char_with_choices\" is \"Literal['a', 'b']\"",
+            line=12,
+            column=13,
+        ),
+        Result(
+            type="error",
+            message="Condition will always evaluate to False since the types \"Literal['a', 'b']\" and \"Literal['c']\" have no overlap (reportUnnecessaryComparison)",
+            line=13,
+            column=1,
+        ),
+        Result(
+            type="error",
+            message='Cannot assign member "char_with_choices" for type "Foo" (reportGeneralTypeIssues)',
+            line=15,
+            column=3,
+        ),
+        Result(
+            type="error",
+            message='Cannot assign member "char_with_choices" for type "Foo" (reportGeneralTypeIssues)',
+            line=16,
+            column=3,
+        ),
+    ]
+
+
+def test_char_with_choices_nullable() -> None:
+    results = run_pyright(
+        """\
+from django.db import models
+
+class Foo(models.Model):
+    char_with_choices_nullable = models.CharField(
+        choices=[
+            ("a", "A"),
+            ("b", "B"),
+        ],
+        null=True,
+    )
+
+f = Foo()
+reveal_type(f.char_with_choices_nullable)
+f.char_with_choices_nullable == "c"
+f.char_with_choices_nullable == "a"
+f.char_with_choices_nullable = None
+f.char_with_choices_nullable = "c"
+f.char_with_choices_nullable = "b"
+"""
+    )
+    assert results == [
+        Result(
+            type="info",
+            message="Type of \"f.char_with_choices_nullable\" is \"Literal['a', 'b'] | None\"",
+            line=13,
+            column=13,
+        ),
+        Result(
+            type="error",
+            message='Cannot assign member "char_with_choices_nullable" for type "Foo" (reportGeneralTypeIssues)',
+            line=17,
+            column=3,
+        ),
+    ]

--- a/tests/trout/models.py
+++ b/tests/trout/models.py
@@ -87,6 +87,19 @@ class Comment(models.Model):
 
     char = models.CharField()
     char_nullable = models.CharField(null=True)
+    char_with_choices = models.CharField(
+        choices=[
+            ("a", "A"),
+            ("b", "B"),
+        ],
+    )
+    char_with_choices_nullable = models.CharField(
+        choices=[
+            ("a", "A"),
+            ("b", "B"),
+        ],
+        null=True,
+    )
 
     text = models.TextField()
     text_nullable = models.TextField(null=True)
@@ -100,6 +113,19 @@ class Comment(models.Model):
 
     integer = models.IntegerField()
     integer_nullable = models.IntegerField(null=True)
+    integer_with_choices = models.IntegerField(
+        choices=[
+            (1, "First Option"),
+            (2, "Second Option"),
+        ],
+    )
+    integer_with_choices_nullable = models.IntegerField(
+        choices=[
+            (1, "First Option"),
+            (2, "Second Option"),
+        ],
+        null=True,
+    )
 
     float = models.FloatField()
     float_nullable = models.FloatField(null=True)
@@ -113,8 +139,8 @@ class Comment(models.Model):
     email = models.EmailField()
     email_nullable = models.EmailField(null=True)
 
-    decimal = models.DecimalField()
-    decimal_nullable = models.DecimalField(null=True)
+    decimal = models.DecimalField(max_digits=20, decimal_places=2)
+    decimal_nullable = models.DecimalField(null=True, max_digits=20, decimal_places=2)
 
     bool = models.BooleanField()
     bool_nullable = models.BooleanField(null=True)
@@ -263,7 +289,7 @@ def main() -> None:
     process_non_nullable(for_sure_c.integer)
 
     # Django way to duplicate an instance
-    comment.id = None
+    comment.pk = None
     comment.save()
 
     print(comment.id)
@@ -321,6 +347,18 @@ def main() -> None:
     if not isinstance(comment.integer, int):
         print()  # type: ignore [unreachable]
     if not comment.integer and not isinstance(comment.integer, int):
+        print()  # type: ignore [unreachable]
+
+    process_non_nullable(comment.integer_with_choices)
+    if isinstance(comment.integer_with_choices_nullable, type(None)):
+        print(comment.integer_with_choices_nullable)
+    if comment.integer_with_choices_nullable is not None:
+        print(comment.integer_with_choices_nullable)
+    if not isinstance(comment.integer_with_choices, int):
+        print()  # type: ignore [unreachable]
+    if not comment.integer_with_choices and not isinstance(
+        comment.integer_with_choices, int
+    ):
         print()  # type: ignore [unreachable]
 
     process_non_nullable(comment.float)
@@ -513,6 +551,16 @@ def main() -> None:
     if not isinstance(comment.ci_char, str):
         print()  # type: ignore [unreachable]
     if not comment.ci_char and not isinstance(comment.ci_char, str):
+        print()  # type: ignore [unreachable]
+
+    process_non_nullable(comment.char_with_choices)
+    if isinstance(comment.char_with_choices_nullable, type(None)):
+        print(comment.char_with_choices_nullable)
+    if comment.char_with_choices_nullable is not None:
+        print(comment.char_with_choices_nullable)
+    if not isinstance(comment.char_with_choices, str):
+        print()  # type: ignore [unreachable]
+    if not comment.char_with_choices and not isinstance(comment.char_with_choices, str):
         print()  # type: ignore [unreachable]
 
     process_non_nullable(comment.ci_email)
@@ -929,7 +977,8 @@ class Foo(models.Model):
         null=True,
         default=None,
         blank=True,
-        max_digits=2,
+        max_digits=4,
+        decimal_places=2,
     )
 
     search_field = SearchVectorField(null=True, help_text="foo")
@@ -944,7 +993,7 @@ class HandField(models.Field[Any, Any]):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["max_length"] = 104
-        super().__init__(*args, **kwargs)  # type: ignore [call-arg]
+        super().__init__(*args, **kwargs)
 
 
 AuthUser.objects.create_superuser(username="foo", email=None, password=None)


### PR DESCRIPTION
This was built on top of https://github.com/sbdchd/django-types/pull/63, so merging it should only keep this PR's change

Note that even though the change looks big, it actually is pretty small, it is just that all fields need to define their own `__new__` (or `__init__` if their signature is different from the base field), and it is all the same, the difference is the classname and the generic field. I also added some documentation [here](https://github.com/sbdchd/django-types/pull/65/files#diff-876a5d116ef70c86039fbb8498623871324fa93fc1ae51c7c09ba2a0f7612e99R47) explaining the usage.

Fix https://github.com/sbdchd/django-types/issues/34