### PR TITLE
Fix migration issues for fields with choices

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -38,9 +38,9 @@ _ErrorMessagesToOverride = Dict[str, Any]
 
 _T = TypeVar("_T", bound="Field[Any, Any]")
 # __set__ value type
-_ST = TypeVar("_ST", contravariant=True)
+_ST = TypeVar("_ST")
 # __get__ return type
-_GT = TypeVar("_GT", covariant=True)
+_GT = TypeVar("_GT")
 
 class NOT_PROVIDED: ...
 

--- a/django-stubs/db/models/fields/json.pyi
+++ b/django-stubs/db/models/fields/json.pyi
@@ -1,5 +1,15 @@
 import json
-from typing import Any, Callable, Iterable, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from django.db.models import lookups
 from django.db.models.lookups import PostgresOperatorLookup, Transform

--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -68,9 +68,9 @@ _ErrorMessagesToOverride = Dict[str, Any]
 RECURSIVE_RELATIONSHIP_CONSTANT: str = ...
 
 # __set__ value type
-_ST = TypeVar("_ST", covariant=True)
+_ST = TypeVar("_ST")
 # __get__ return type
-_GT = TypeVar("_GT", contravariant=True)
+_GT = TypeVar("_GT")
 
 class RelatedField(FieldCacheMixin, Field[_ST, _GT]):
     one_to_many: bool = ...

--- a/tests/pyright/test_migrations.py
+++ b/tests/pyright/test_migrations.py
@@ -1,0 +1,38 @@
+from .base import run_pyright
+
+
+def test_integer_with_choices() -> None:
+    results = run_pyright(
+        """\
+from django.db import migrations, models
+
+migrations.AlterField(
+    model_name="test_model",
+    name="test_field",
+    field=models.CharField(
+        choices=[
+            ("foo", "Foo"),
+            ("bar", "Bar"),
+        ],
+        default=None,
+        max_length=3,
+        null=True,
+    ),
+)
+
+migrations.AddField(
+    model_name="test_model",
+    name="test_related_field",
+    field=models.ForeignKey(
+        blank=True,
+        default=None,
+        null=True,
+        on_delete=models.deletion.PROTECT,
+        related_name="test_fields",
+        to="some.other.Model",
+    ),
+)
+"""
+    )
+    # NOTE: Those would fail when _ST/_GT were set to covariant/contravariant
+    assert results == []


### PR DESCRIPTION
Just upgraded to 0.11.0 and notice some errors on my migrations. There's no need to set covariant/contravariant on _GT/_ST.

The tests are just there to make sure that there are no errors anymore. If the code is reverted the test would fail