### PR TITLE
Add db_table kwarg to ManyToManyField constructor

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -465,6 +465,7 @@ class ManyToManyField(
         choices: Optional[_FieldChoices] = ...,
         help_text: str = ...,
         db_column: Optional[str] = ...,
+        db_table: Optional[str] = ...,
         db_tablespace: Optional[str] = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: Optional[_ErrorMessagesToOverride] = ...,


### PR DESCRIPTION
I think that it was removed in one of the recent PRs for improving `ManyToManyField` typing.
