### PR TITLE
Allow adding and removing field values (typically primary keys) in many-to-many relationships.

### DIFF
--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -63,10 +63,10 @@ class ManyToManyRelatedManager(Generic[_T, _V], Manager[_T]):
     through: RelatedManager[_V]
     def add(
         self,
-        *objs: Union[QuerySet[_T], _T],
+        *objs: Union[QuerySet[_T], _T, _V],
         through_defaults: MutableMapping[str, Any] = ...,
     ) -> None: ...
-    def remove(self, *objs: Union[QuerySet[_T], _T]) -> None: ...
+    def remove(self, *objs: Union[QuerySet[_T], _T, _V]) -> None: ...
     def set(
         self,
         objs: Union[QuerySet[_T], Iterable[_T]],


### PR DESCRIPTION
From the docs for `add()`:
https://docs.djangoproject.com/en/4.0/ref/models/relations/#django.db.models.fields.related.RelatedManager.add

> For many-to-many relationships add() accepts either model instances or field values, normally primary keys, as the *objs argument.

Likewise for `remove()`:
https://docs.djangoproject.com/en/4.0/ref/models/relations/#django.db.models.fields.related.RelatedManager.remove

> For many-to-many relationships remove() accepts either model instances or field values, normally primary keys, as the *objs argument.
