### PR TITLE
fix: Fix type errors after upgrading pyright to 1.1.271 in `path` fun…

### DIFF
--- a/django-stubs/urls/conf.pyi
+++ b/django-stubs/urls/conf.pyi
@@ -14,7 +14,7 @@ from ..conf.urls import IncludedURLConf
 from ..http.response import HttpResponseBase
 from .resolvers import URLPattern, URLResolver
 
-_ResponseType = Union[HttpResponseBase, Coroutine[Any, Any, HttpResponseBase]]
+_ResponseType = Union[HttpResponseBase, Coroutine[Any, Any, HttpResponseBase], Coroutine[Any, Any, None]]
 
 def include(
     arg: Any, namespace: Optional[str] = ...


### PR DESCRIPTION
…ction with async views from `channels`.

![Screenshot from 2022-09-15 13-46-08](https://user-images.githubusercontent.com/301015/190384860-d2619b9f-5910-46b8-abff-578d1672acd1.png)

here is the problem, _ResponseType is defined like this:
```
_ResponseType = Union[HttpResponseBase, Coroutine[Any, Any, HttpResponseBase]]
```

But async consumer from channels is returning `None`, it was `Unknown` in previous pyright releases, so it was working.

Looking at the `AsyncConsumer.__call__` signature, it is indeed does not return anything.

`Coroutine[Any, Any, HttpResponseBase]` is expected to handle async django views?

And we need to add `Coroutine[Any, Any, None]` to support `channels`. Is this sounds right?