### PR TITLE
fix: Add `through` to ManyToManyField

### DIFF
--- a/django-stubs/db/models/fields/related.pyi
+++ b/django-stubs/db/models/fields/related.pyi
@@ -370,6 +370,7 @@ class ManyToManyField(
     has_null_arg: Any = ...
     swappable: bool = ...
     related_model: Type[_MM] = ...  # type: ignore [assignment]
+    through: Type[_MN]
     def __new__(
         cls,
         to: Union[Type[_MM], str],


### PR DESCRIPTION
By the way, why other typings here using ` = ...`?

Should i also add `= ...` to this line?