### PR TITLE
Replace exception classes with ClassVars

### DIFF
--- a/django-stubs/db/models/base.pyi
+++ b/django-stubs/db/models/base.pyi
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Collection,
     Dict,
     Iterable,
@@ -42,8 +43,8 @@ class ModelBase(type):
     def _default_manager(cls: Type[_M]) -> BaseManager[_M]: ...
 
 class Model(metaclass=ModelBase):
-    class DoesNotExist(ObjectDoesNotExist): ...
-    class MultipleObjectsReturned(BaseMultipleObjectsReturned): ...
+    DoesNotExist: ClassVar[type[ObjectDoesNotExist]]
+    MultipleObjectsReturned: ClassVar[type[BaseMultipleObjectsReturned]]
     class Meta: ...
     pk: Any = ...
     _state: ModelState


### PR DESCRIPTION
Addresses https://github.com/microsoft/pylance-release/issues/3918

As currently defined, type checkers see the `Model.DoesNotExist` and `Model.MultipleObjectsReturned` exception types as being the same on all `Model` types.

I'm replacing the exception `class` declarations on `Model` with `ClassVar` so each `Model` type will have a distinct set of exception types, allowing the usage below without type checkers thinking that the later `except` clauses are unreachable.

```python
from django.db import models

class User(models.Model):
    email = models.EmailField(max_length=250)

class Notification(models.Model):
    message = models.CharField(max_length=250)

class Media(models.Model):
    file = models.FileField()

def do_things(user_id: int, notification_id: int, media_id: Media) -> None:
    try:
        user = User.objects.get(id=user_id)
        note = Notification.objects.get(id=notification_id)
        media = Media.objects.get(id=media_id)
    except User.DoesNotExist:
        raise Exception(f"User with id {user_id} does not exist.")
    except Notification.DoesNotExist:
        raise Exception(f"Notification with id {notification_id} does not exist.") # <- Pylance marks this as unreachable
    except Media.DoesNotExist:
        raise Exception("Example exception") # <- Pylance marks this as unreachable
```