### PR TITLE
Add RenameIndex migrate operation

### DIFF
--- a/django-stubs/db/migrations/operations/models.pyi
+++ b/django-stubs/db/migrations/operations/models.pyi
@@ -83,6 +83,23 @@ class RemoveIndex(IndexOperation):
     name: str = ...
     def __init__(self, model_name: str, name: Union[str, Index]) -> None: ...
 
+class RenameIndex(IndexOperation):
+    model_name: str
+    new_name: str
+    old_name: str | None
+    old_fields: Sequence[str] | None
+    def __init__(
+        self,
+        model_name: str,
+        new_name: str,
+        old_name: str | None = ...,
+        old_fields: Sequence[str] | None = ...,
+    ) -> None: ...
+    @property
+    def old_name_lower(self) -> str: ...
+    @property
+    def new_name_lower(self) -> str: ...
+
 class AddConstraint(IndexOperation):
     def __init__(self, model_name: str, constraint: BaseConstraint) -> None: ...
 


### PR DESCRIPTION
This adds the `RenameIndex` operation which is part of Django since 4.1 (https://docs.djangoproject.com/en/4.2/ref/migration-operations/#renameindex).