### PR TITLE
Add allow_unicode to SlugField

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -718,6 +718,7 @@ class SlugField(CharField[_C]):
         db_tablespace: str | None = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: _ErrorMessagesToOverride | None = ...,
+        allow_unicode: bool = ...
     ) -> SlugField[str]: ...
     @overload
     def __new__(
@@ -744,6 +745,7 @@ class SlugField(CharField[_C]):
         db_tablespace: str | None = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: _ErrorMessagesToOverride | None = ...,
+        allow_unicode: bool = ...
     ) -> SlugField[str | None]: ...
 
 class EmailField(CharField[_C]):


### PR DESCRIPTION
### Description
- Add `allow_unicode` to SlugField (see: https://docs.djangoproject.com/en/5.0/ref/models/fields/#slugfield)