### PR TITLE
Add another overload to path function

### DIFF
--- a/django-stubs/urls/conf.pyi
+++ b/django-stubs/urls/conf.pyi
@@ -32,6 +32,13 @@ def path(
     kwargs: dict[str, Any] = ...,
     name: str = ...,
 ) -> URLResolver: ...
+@overload
+def path(
+    route: str,
+    view: tuple[list[URLResolver | URLPattern], str, str],
+    kwargs: dict[str, Any] = ...,
+    name: str = ...,
+) -> URLResolver: ...
 
 # re_path()
 @overload


### PR DESCRIPTION
Allows to pass NinjaAPI's ``.urls`` to Django's ``path`` function.

Adding ``URLPattern`` to ``IncludedURLConf`` didn't work. My guess is that this is caused by the `str | None` in ``IncludedURLConf`` which is not as strict as the return type of ``ninja_api.urls``

fixes sbdchd/django-types#173