### PR TITLE
Add ManyToManyRelatedManager to auth models

### DIFF
--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -9,7 +9,7 @@ from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import Model
-from django.db.models.manager import EmptyManager
+from django.db.models.manager import EmptyManager, ManyToManyRelatedManager
 
 _AnyUser = Model | AnonymousUser
 
@@ -34,6 +34,7 @@ class Permission(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     codename = models.CharField(max_length=100)
     def natural_key(self) -> tuple[str, str, str]: ...
+    group_set = ManyToManyRelatedManager["Group", "Permission"]()
 
 _GroupT = TypeVar("_GroupT", bound=Group)
 
@@ -46,6 +47,7 @@ class Group(models.Model):
     name = models.CharField(max_length=150)
     permissions = models.ManyToManyField[Permission, Any](Permission)
     def natural_key(self) -> tuple[str, ...]: ...
+    user_set = ManyToManyRelatedManager["PermissionsMixin", "Group"]()
 
 class UserManager(BaseUserManager[_T]):
     def create_user(


### PR DESCRIPTION
Adds managers for reverse names of many to many relationships in the contrib.auth app.

This is a small QoL improvement PR. It provides type checkers with the reverse relationships between:

- Group and Permission: Permission has a typed `.group_set` manager object
- PermissionMixin and Group: Group has a typed `.user_set` manager object

The reasons for using _PermissionMixin_ rather than other possible models/mixins are (1) the relationship is defined in the mixin to begin with, and (2) this is compatible with any model that inherits the mixin - e.g. AbstractUser, User, or a custom user model.

<img width="759" alt="Screenshot 2024-04-19 at 10 34 19 AM" src="https://github.com/sbdchd/django-types/assets/4360430/40dc3ce6-fd5a-4c7f-8318-5bbff80c5b9f">
