### PR TITLE
`django.utils.deconstruct`: Improve types

### DIFF
--- a/django-stubs/utils/deconstruct.pyi
+++ b/django-stubs/utils/deconstruct.pyi
@@ -1,3 +1,11 @@
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
 
-def deconstructible(*args: Any, path: Any | None = ...) -> Any: ...
+T = TypeVar("T")
+
+@overload
+def deconstructible(klass: type[T]) -> type[T]: ...
+@overload
+def deconstructible(
+    *args: Any, path: str | None = ...
+) -> Callable[[type[T]], type[T]]: ...


### PR DESCRIPTION
Adds generic type hints to [`@deconstructible`](https://docs.djangoproject.com/en/4.2/topics/migrations/#adding-a-deconstruct-method) so that it preserves the implicit types of the class it decorates.

I don't know of a way to indicate that the class it returns has a `decorator()` method attached to it.