### PR TITLE
`db/models/fields/__init__.pyi`: Black format

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -720,7 +720,7 @@ class SlugField(CharField[_C]):
         db_tablespace: str | None = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: _ErrorMessagesToOverride | None = ...,
-        allow_unicode: bool = ...
+        allow_unicode: bool = ...,
     ) -> SlugField[str]: ...
     @overload
     def __new__(
@@ -747,7 +747,7 @@ class SlugField(CharField[_C]):
         db_tablespace: str | None = ...,
         validators: Iterable[_ValidatorCallable] = ...,
         error_messages: _ErrorMessagesToOverride | None = ...,
-        allow_unicode: bool = ...
+        allow_unicode: bool = ...,
     ) -> SlugField[str | None]: ...
 
 class EmailField(CharField[_C]):


### PR DESCRIPTION
Black wants to add a trailing comma to the multiline arguments.

Produced by running `./s/lint`.