### PR TITLE
Add optional `nulls_distinct` arg to UniqueConstraint, which maps to …

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -61,4 +61,5 @@ class UniqueConstraint(BaseConstraint):
         include: str | Sequence[str] | None = ...,
         opclasses: Sequence[str] = ...,
         violation_error_message: str | None = ...,
+        nulls_distinct: bool | None = ...,
     ) -> None: ...


### PR DESCRIPTION
- Add optional `nulls_distinct` arg to `UniqueConstraint`, which maps to `NULLS NOT DISTINCT` in SQL
- See https://code.djangoproject.com/ticket/34701
- Also https://www.postgresql.org/docs/current/indexes-unique.html