### PR TITLE
Allow text choices being directly assigned as choices.

### DIFF
--- a/django-stubs/db/models/fields/__init__.pyi
+++ b/django-stubs/db/models/fields/__init__.pyi
@@ -8,7 +8,7 @@ from typing_extensions import Literal, Self
 
 from django.core.checks import CheckMessage
 from django.core.exceptions import FieldDoesNotExist as FieldDoesNotExist
-from django.db.models import Model
+from django.db.models import Model, TextChoices
 from django.db.models.expressions import Col, Combinable
 from django.db.models.query_utils import RegisterLookupMixin
 from django.forms import Widget
@@ -679,7 +679,8 @@ class CharField(Generic[_C], Field[_C | Combinable, _C]):
         unique_for_date: str | None = ...,
         unique_for_month: str | None = ...,
         unique_for_year: str | None = ...,
-        choices: Iterable[tuple[_C, str] | tuple[str, Iterable[tuple[_C, str]]]] = ...,
+        choices: Iterable[tuple[_C, str] | tuple[str, Iterable[tuple[_C, str]]]]
+        | type[TextChoices] = ...,
         help_text: str = ...,
         db_column: str | None = ...,
         db_comment: str | None = ...,
@@ -706,7 +707,8 @@ class CharField(Generic[_C], Field[_C | Combinable, _C]):
         unique_for_date: str | None = ...,
         unique_for_month: str | None = ...,
         unique_for_year: str | None = ...,
-        choices: Iterable[tuple[_C, str] | tuple[str, Iterable[tuple[_C, str]]]] = ...,
+        choices: Iterable[tuple[_C, str] | tuple[str, Iterable[tuple[_C, str]]]]
+        | type[TextChoices] = ...,
         help_text: str = ...,
         db_column: str | None = ...,
         db_comment: str | None = ...,


### PR DESCRIPTION
Allow CharField(choices=...) to be a TextChoices class.

Changed in Django 5.0, see note here: https://docs.djangoproject.com/en/5.0/ref/models/fields/#s-enumeration-types