### PR TITLE
Update constaints for Django 5

### DIFF
--- a/django-stubs/db/models/constraints.pyi
+++ b/django-stubs/db/models/constraints.pyi
@@ -14,10 +14,13 @@ class Deferrable(Enum):
 
 class BaseConstraint:
     name: str
+    violation_error_code: str | None
+    violation_error_message: str | None
     def __init__(
         self,
         *args: BaseExpression | Combinable | str,
         name: str | None = ...,
+        violation_error_code: str | None = ...,
         violation_error_message: str | None = ...,
     ) -> None: ...
     def constraint_sql(
@@ -39,12 +42,15 @@ class BaseConstraint:
     def clone(self) -> Self: ...
 
 class CheckConstraint(BaseConstraint):
-    check: Q
+    condition: Q
+    check: Q | None
     def __init__(
         self,
         *,
-        check: Q,
         name: str,
+        condition: Q | None = ...,
+        check: Q | None = ...,
+        violation_error_code: str | None = ...,
         violation_error_message: str | None = ...,
     ) -> None: ...
 
@@ -60,6 +66,7 @@ class UniqueConstraint(BaseConstraint):
         deferrable: Deferrable | None = ...,
         include: str | Sequence[str] | None = ...,
         opclasses: Sequence[str] = ...,
-        violation_error_message: str | None = ...,
         nulls_distinct: bool | None = ...,
+        violation_error_code: str | None = ...,
+        violation_error_message: str | None = ...,
     ) -> None: ...


### PR DESCRIPTION
Django 5 added:
- `BaseConstraint.violation_error_code` and corresponding `__init__` parameter.
- CheckConstraint.condition` to replace `check` and corresponding `__init__` parameter.
  - The use of `check` now emits a Django6 deprecation warning, but can't change it without updating the types.

https://github.com/django/django/blob/stable/5.1.x/django/db/models/constraints.py