### PR TITLE
Update transaction.pyi

### DIFF
--- a/django-stubs/db/transaction.pyi
+++ b/django-stubs/db/transaction.pyi
@@ -2,6 +2,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import Any, TypeVar, overload
 
+from types import TracebackType
 from django.db import ProgrammingError
 
 class TransactionManagementError(ProgrammingError): ...
@@ -35,8 +36,12 @@ class Atomic:
     # When decorating, return the decorated function as-is, rather than clobbering it as ContextDecorator does.
     def __call__(self, func: _C) -> _C: ...
     def __enter__(self) -> None: ...
-    def __exit__(self, exc_type: None, exc_value: None, traceback: None) -> None: ...
-
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None, /
+    ) -> None: ...
 # Bare decorator
 @overload
 def atomic(using: _C) -> _C: ...


### PR DESCRIPTION
Make `transaction.atomic` compatible with `AbstractContextManager` protocol.

Currently the following error is reported by pyright:
```python
from contextlib import AbstractContextManager
from django.db import transaction

x: AbstractContextManager[None, None] = transaction.atomic()
```
```
Type "Atomic" is not assignable to declared type "AbstractContextManager[None, None]"
  "Atomic" is incompatible with protocol "AbstractContextManager[None, None]"
    "__exit__" is an incompatible type
      Type "(exc_type: None, exc_value: None, traceback: None) -> None" is not assignable to type "(exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None, /) -> _ExitT_co@AbstractContextManager"
        Parameter 1: type "type[BaseException] | None" is incompatible with type "None"
          Type "type[BaseException] | None" is not assignable to type "None"
        Parameter 2: type "BaseException | None" is incompatible with type "None"
          Type "BaseException | None" is not assignable to type "None"
        Parameter 3: type "TracebackType | None" is incompatible with type "None"
        
```