### PR TITLE
ValidationError message argument is recursively defined

### DIFF
--- a/django-stubs/core/exceptions.pyi
+++ b/django-stubs/core/exceptions.pyi
@@ -26,6 +26,15 @@ class FieldError(Exception): ...
 
 NON_FIELD_ERRORS: str
 
+
+ValidationErrorMessageArg = (
+    str
+    | ValidationError
+    | dict[str, ValidationErrorMessageArg]
+    | list[ValidationErrorMessageArg]
+)
+
+
 class ValidationError(Exception):
     error_dict: dict[str, list[ValidationError]] | None
     error_list: list[ValidationError] | None
@@ -34,12 +43,7 @@ class ValidationError(Exception):
     params: Mapping[str, Any] | None
     def __init__(
         self,
-        message: (
-            ValidationError
-            | dict[str, ValidationError | list[str]]
-            | list[ValidationError | str]
-            | str
-        ),
+        message: ValidationErrorMessageArg,
         code: str | None = ...,
         params: Mapping[str, Any] | None = ...,
     ) -> None: ...


### PR DESCRIPTION
use a recursive type definition for `ValidationError` to match the [actual implementation (4.2)](https://github.com/django/django/blob/7bd1ddf1d81e9120c28322ee2a0b9c11941a6af2/django/core/exceptions.py#L133-L178)

should resolve #280