### PR TITLE
fix: Third argument for ngettext_lazy is optional

### DIFF
--- a/django-stubs/utils/translation/__init__.pyi
+++ b/django-stubs/utils/translation/__init__.pyi
@@ -46,7 +46,9 @@ gettext_lazy = gettext
 ugettext_lazy = ugettext
 pgettext_lazy = pgettext
 
-def ngettext_lazy(singular: str, plural: str, number: int | str | None) -> str: ...
+def ngettext_lazy(
+    singular: str, plural: str, number: int | str | None = ...
+) -> str: ...
 
 ungettext_lazy = ngettext_lazy
 


### PR DESCRIPTION
Refs https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#lazy-translations-and-plural