### PR TITLE
Add `current_app` to `HttpRequest`

### DIFF
--- a/django-stubs/http/request.pyi
+++ b/django-stubs/http/request.pyi
@@ -3,8 +3,7 @@ from re import Pattern
 from typing import Any, BinaryIO, TypeVar, overload
 from typing_extensions import Self
 
-from django.contrib.auth.base_user import AbstractBaseUser
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import _AnyUser
 from django.contrib.sessions.backends.base import SessionBase
 from django.contrib.sites.models import Site
 from django.core.files import uploadedfile, uploadhandler
@@ -96,9 +95,14 @@ class HttpRequest:
     def __iter__(self) -> Iterable[bytes]: ...
     def readlines(self) -> list[bytes]: ...
 
-    # Attributes added by commonly-used middleware
-    user: AbstractBaseUser | AnonymousUser
+    # Attributes added by optional parts of Django
+    # django.contrib.admin views:
+    current_app: str
+    # django.contrib.auth.middleware.AuthenticationMiddleware:
+    user: _AnyUser
+    # django.contrib.sites.middleware.CurrentSiteMiddleware
     site: Site
+    # django.contrib.sessions.middleware.SessionMiddleware
     session: SessionBase
 
 class QueryDict(MultiValueDict[str, str]):


### PR DESCRIPTION
- Added `current_app` to `HttpRequest`.
- Added comments to the same section of HttpRequest and used `_AnyUser` instead of `AbstractBaseUser | AnonymousUser` a la [django-stubs](https://github.com/typeddjango/django-stubs/blob/01c1c03acd468dace6fc42556b59d6a9967dfa5b/django-stubs/http/request.pyi#L53-L65).

closes #253