### PR TITLE
Fix link to `django_stubs_ext` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ Type stubs for [Django](https://www.djangoproject.com).
 pip install django-types
 ```
 
+### I cannot use QuerySet or Manager with type annotations
+
 You can get a `TypeError: 'type' object is not subscriptable`
 when you will try to use `QuerySet[MyModel]`, `Manager[MyModel]` or some other Django-based Generic types.
 
 This happens because these Django classes do not support [`__class_getitem__`](https://www.python.org/dev/peps/pep-0560/#class-getitem) magic method in runtime.
 
-1. You can go with [`django_stubs_ext`](https://github.com/typeddjango/django-stubs/tree/master/django_stubs_ext) helper, that patches all the types we use as Generic in django.
+1. You can go with [`django_stubs_ext`](https://github.com/typeddjango/django-stubs/tree/master/ext) helper, that patches all the types we use as Generic in django.
 
    Install it:
 


### PR DESCRIPTION
closes #216 

- Fixed the broken link to `django_stubs_ext` in the README.md file.
- Added an additional header to this section because monkeypatching instructions _appeared_ to fall under the "install" heading giving the impression that this is mandatory, when in fact it only applies to old Django versions and probably isn't required for most users now.