### PR TITLE
Add `query` and `fragment` parameters to `reverse` type definition

### DIFF
--- a/django-stubs/urls/base.pyi
+++ b/django-stubs/urls/base.pyi
@@ -1,7 +1,20 @@
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Mapping, TypeAlias
 
+from django.http.request import QueryDict
 from django.urls.resolvers import ResolverMatch
+
+# The values are passed through `str()` (unless they are bytes), so anything is valid.
+_QueryType: TypeAlias = (
+    Mapping[str, object]
+    | Mapping[bytes, object]
+    | Mapping[str | bytes, object]
+    | Mapping[str, Sequence[object]]
+    | Mapping[bytes, Sequence[object]]
+    | Mapping[str | bytes, Sequence[object]]
+    | Sequence[tuple[str | bytes, object]]
+    | Sequence[tuple[str | bytes, Sequence[object]]]
+)
 
 def resolve(path: str, urlconf: str | None = ...) -> ResolverMatch: ...
 def reverse(
@@ -10,6 +23,9 @@ def reverse(
     args: Sequence[Any] | None = ...,
     kwargs: dict[str, Any] | None = ...,
     current_app: str | None = ...,
+    *,
+    query: QueryDict | _QueryType | None = ...,
+    fragment: str | None = ...,
 ) -> str: ...
 
 reverse_lazy: Any

--- a/django-stubs/urls/base.pyi
+++ b/django-stubs/urls/base.pyi
@@ -1,5 +1,6 @@
-from collections.abc import Callable, Sequence
-from typing import Any, Mapping, TypeAlias
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+from typing_extensions import TypeAlias
 
 from django.http.request import QueryDict
 from django.urls.resolvers import ResolverMatch


### PR DESCRIPTION
New in Django 5.2

Fixed the mypy failures with the previous version