### PR TITLE
Fix Black formatting violations.

### DIFF
--- a/django-stubs/contrib/admin/options.pyi
+++ b/django-stubs/contrib/admin/options.pyi
@@ -17,7 +17,8 @@ from django.db.models.fields import Field
 from django.db.models.fields.related import ForeignKey, ManyToManyField, RelatedField
 from django.db.models.options import Options
 from django.db.models.query import QuerySet
-from django.forms.fields import Field as FormField, TypedChoiceField
+from django.forms.fields import Field as FormField
+from django.forms.fields import TypedChoiceField
 from django.forms.forms import BaseForm
 from django.forms.models import (
     BaseInlineFormSet,

--- a/django-stubs/contrib/admin/views/autocomplete.pyi
+++ b/django-stubs/contrib/admin/views/autocomplete.pyi
@@ -4,7 +4,6 @@ from django.contrib.admin.options import ModelAdmin
 from django.http.request import HttpRequest
 from django.views.generic.list import BaseListView
 
-
 class AutocompleteJsonView(BaseListView):
     model_admin: ModelAdmin[Any] = ...
     term: Any = ...

--- a/django-stubs/contrib/admin/views/main.pyi
+++ b/django-stubs/contrib/admin/views/main.pyi
@@ -14,7 +14,6 @@ from django.forms.formsets import BaseFormSet
 from django.forms.models import ModelForm
 from django.http.request import HttpRequest
 
-
 ALL_VAR: str
 ORDER_VAR: str
 ORDER_TYPE_VAR: str

--- a/django-stubs/contrib/syndication/views.pyi
+++ b/django-stubs/contrib/syndication/views.pyi
@@ -7,7 +7,6 @@ from django.http.response import HttpResponse
 from django.utils.feedgenerator import Enclosure, SyndicationFeed
 from django.utils.safestring import SafeText
 
-
 def add_domain(domain: str, url: str, secure: bool = ...) -> str: ...
 
 class FeedDoesNotExist(ObjectDoesNotExist): ...

--- a/django-stubs/core/exceptions.pyi
+++ b/django-stubs/core/exceptions.pyi
@@ -26,14 +26,12 @@ class FieldError(Exception): ...
 
 NON_FIELD_ERRORS: str
 
-
 ValidationErrorMessageArg = (
     str
     | ValidationError
     | dict[str, ValidationErrorMessageArg]
     | list[ValidationErrorMessageArg]
 )
-
 
 class ValidationError(Exception):
     error_dict: dict[str, list[ValidationError]] | None


### PR DESCRIPTION
Ran `./s/lint` and found that Black reformatted a few files, mostly because of whitespace.