### PR TITLE
[Django 5.0] ChoicesType type alias for ChoicesMeta

### DIFF
--- a/django-stubs/db/models/enums.pyi
+++ b/django-stubs/db/models/enums.pyi
@@ -1,6 +1,15 @@
 import enum
+import sys
 from collections.abc import Sequence
 from typing import Any, TypeVar
+
+if sys.version_info < (3, 12):
+    from typing import TypeAlias
+
+    ChoicesType: TypeAlias = ChoicesMeta
+
+else:
+    type ChoicesType = ChoicesMeta
 
 _EnumMemberT = TypeVar("_EnumMemberT")
 

--- a/django-stubs/db/models/enums.pyi
+++ b/django-stubs/db/models/enums.pyi
@@ -1,15 +1,6 @@
 import enum
-import sys
 from collections.abc import Sequence
-from typing import Any, TypeVar
-
-if sys.version_info < (3, 12):
-    from typing import TypeAlias
-
-    ChoicesType: TypeAlias = "ChoicesMeta"
-
-else:
-    type ChoicesType = ChoicesMeta
+from typing import Any, TypeAlias, TypeVar
 
 _EnumMemberT = TypeVar("_EnumMemberT")
 
@@ -21,6 +12,8 @@ class ChoicesMeta(enum.EnumMeta):
     def values(self: type[_EnumMemberT]) -> Sequence[_EnumMemberT]: ...
     @property
     def choices(self: type[_EnumMemberT]) -> Sequence[tuple[_EnumMemberT, str]]: ...
+
+ChoicesType: TypeAlias = ChoicesMeta
 
 class Choices(enum.Enum, metaclass=ChoicesMeta):
     def __str__(self) -> Any: ...

--- a/django-stubs/db/models/enums.pyi
+++ b/django-stubs/db/models/enums.pyi
@@ -6,7 +6,7 @@ from typing import Any, TypeVar
 if sys.version_info < (3, 12):
     from typing import TypeAlias
 
-    ChoicesType: TypeAlias = ChoicesMeta
+    ChoicesType: TypeAlias = "ChoicesMeta"
 
 else:
     type ChoicesType = ChoicesMeta


### PR DESCRIPTION
[Django 5.0 deprecates ChoicesMeta](https://docs.djangoproject.com/en/5.2/releases/5.0/#features-deprecated-in-5-0) favour of `ChoicesType` (renamed).

Ported the equivalent [django-stubs change for this deprecation](https://github.com/typeddjango/django-stubs/pull/1942).
