### PR TITLE
fix: Context managers should use BaseException

### DIFF
--- a/django-stubs/test/utils.pyi
+++ b/django-stubs/test/utils.pyi
@@ -61,8 +61,8 @@ class TestContextDecorator:
     def __enter__(self) -> Any | None: ...
     def __exit__(
         self,
-        exc_type: type[Exception] | None,
-        exc_value: Exception | None,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None: ...
     def decorate_class(self, cls: _TestClassGeneric) -> _TestClassGeneric: ...


### PR DESCRIPTION
I've started to adopt `pyrefly` type checker, and I'm catching some errors in our types.

For example, here. Context manager is supposed to use BaseException here.

Refs https://github.com/facebook/pyrefly/discussions/948