### PR TITLE
add GeneratedField

### DIFF
--- a/django-stubs/db/models/fields/generated.pyi
+++ b/django-stubs/db/models/fields/generated.pyi
@@ -1,0 +1,70 @@
+from typing import Any, Literal, TypeVar, overload
+from django.db.models import Combinable
+
+from collections.abc import Iterable
+
+from . import Field, _ErrorMessagesToOverride, _ValidatorCallable
+
+__all__ = ["GeneratedField"]
+
+_A = TypeVar("_A", bound=Any | None)
+
+class GeneratedField(Field[_A | Combinable, _A]):
+    @overload
+    def __new__(
+        cls,
+        verbose_name: str | None = ...,
+        *,
+        name: str | None = ...,
+        primary_key: bool = ...,
+        max_length: int | None = ...,
+        unique: bool = ...,
+        blank: Literal[True] = ...,
+        null: Literal[False] = False,
+        db_index: bool = ...,
+        default: None = ...,
+        editable: bool = ...,
+        auto_created: bool = ...,
+        serialize: bool = ...,
+        unique_for_date: str | None = ...,
+        unique_for_month: str | None = ...,
+        unique_for_year: str | None = ...,
+        choices: Iterable[
+            tuple[Any, str] | tuple[str, Iterable[tuple[Any, str]]]
+        ] = ...,
+        help_text: str = ...,
+        db_column: str | None = ...,
+        db_tablespace: str | None = ...,
+        db_default: None = ...,
+        validators: Iterable[_ValidatorCallable] = ...,
+        error_messages: _ErrorMessagesToOverride | None = ...,
+    ) -> GeneratedField[_A]: ...
+    @overload
+    def __new__(
+        cls,
+        verbose_name: str | None = ...,
+        *,
+        name: str | None = ...,
+        primary_key: bool = ...,
+        max_length: int | None = ...,
+        unique: bool = ...,
+        blank: Literal[True] = ...,
+        null: Literal[True],
+        db_index: bool = ...,
+        default: None = ...,
+        editable: bool = ...,
+        auto_created: bool = ...,
+        serialize: bool = ...,
+        unique_for_date: str | None = ...,
+        unique_for_month: str | None = ...,
+        unique_for_year: str | None = ...,
+        choices: Iterable[
+            tuple[Any, str] | tuple[str, Iterable[tuple[Any, str]]]
+        ] = ...,
+        help_text: str = ...,
+        db_column: str | None = ...,
+        db_tablespace: str | None = ...,
+        db_default: None = ...,
+        validators: Iterable[_ValidatorCallable] = ...,
+        error_messages: _ErrorMessagesToOverride | None = ...,
+    ) -> GeneratedField[_A | None]: ...


### PR DESCRIPTION
`GeneratedField` was added in Django 5.0. I am making this pull request as a draft as I'd like to find out how to contribute to this repository (would love to also document that in a `CONTRIBUTING.md`).

I based this on `JSONField` implementation and main changes were taken based on the `__init__` in source:
```
def __init__(self, *, expression, output_field, db_persist=None, **kwargs):
        if kwargs.setdefault("editable", False):
            raise ValueError("GeneratedField cannot be editable.")
        if not kwargs.setdefault("blank", True):
            raise ValueError("GeneratedField must be blank.")
        if kwargs.get("default", NOT_PROVIDED) is not NOT_PROVIDED:
            raise ValueError("GeneratedField cannot have a default.")
        if kwargs.get("db_default", NOT_PROVIDED) is not NOT_PROVIDED:
            raise ValueError("GeneratedField cannot have a database default.")
        if db_persist not in (True, False):
            raise ValueError("GeneratedField.db_persist must be True or False.")
```


