### PR TITLE
fix: Align assertNotContains signature with Django runtime

### DIFF
--- a/django-stubs/test/testcases.pyi
+++ b/django-stubs/test/testcases.pyi
@@ -80,8 +80,8 @@ class SimpleTestCase(unittest.TestCase):
     ) -> None: ...
     def assertNotContains(
         self,
-        response: HttpResponse,
-        text: bytes | str,
+        response: HttpResponseBase,
+        text: bytes | int | str,
         status_code: int = ...,
         msg_prefix: str = ...,
         html: bool = ...,


### PR DESCRIPTION
fixes https://github.com/sbdchd/django-types/issues/302