### PR TITLE
Export RenameIndex migration operation

### DIFF
--- a/django-stubs/db/migrations/operations/__init__.pyi
+++ b/django-stubs/db/migrations/operations/__init__.pyi
@@ -14,6 +14,7 @@ from .models import CreateModel as CreateModel
 from .models import DeleteModel as DeleteModel
 from .models import RemoveConstraint as RemoveConstraint
 from .models import RemoveIndex as RemoveIndex
+from .models import RenameIndex as RenameIndex
 from .models import RenameModel as RenameModel
 from .special import RunPython as RunPython
 from .special import RunSQL as RunSQL


### PR DESCRIPTION
I noticed that while this was implemented a while back, the type checker still complained as it wasn't included in the init file.
