### PR TITLE
adding meta stub for session

### DIFF
--- a/django-stubs/contrib/sessions/base_session.pyi
+++ b/django-stubs/contrib/sessions/base_session.pyi
@@ -16,6 +16,11 @@ class BaseSessionManager(models.Manager[_SessionT]):
 class AbstractBaseSession(models.Model):
     objects: ClassVar[BaseSessionManager[Self]]  # type: ignore[assignment]
 
+    class Meta:
+        abstract: ClassVar[bool]
+        verbose_name: ClassVar[str]
+        verbose_name_plural: ClassVar[str]
+
     session_key: models.CharField[str]
     session_data: models.TextField[str]
     expire_date: models.DateTimeField[datetime]


### PR DESCRIPTION
Adding missing meta stub for session according to this [PR](https://github.com/typeddjango/django-stubs/pull/3200),
This is needed to solve the name-defined errors 